### PR TITLE
Wait for tx receipts

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -252,6 +252,7 @@ const main = async () => {
     args: [currentAuctionRound, bob.address],
   });
   console.log(`Transfer EL controller transaction hash: ${transferELC}`);
+  await client.waitForTransactionReceipt({ hash: transferELC })
 
   // Wait a few seconds
   await sleep(1000 * secondsToWaitInBetweenELTransactions);

--- a/scripts/withdrawFunds.ts
+++ b/scripts/withdrawFunds.ts
@@ -50,6 +50,7 @@ const main = async () => {
     value: 1n,
   });
   // console.log(`Transaction sent: ${hash}`);
+  await client.waitForTransactionReceipt({ hash: hash })
 
   // Get funds deposited
   console.log(`Checking deposited funds by ${account.address}`);
@@ -77,6 +78,7 @@ const main = async () => {
     functionName: 'initiateWithdrawal',
   });
   console.log(`Initiate withdrawal transaction sent: ${initWithdrawalTransaction}`);
+  await client.waitForTransactionReceipt({ hash: initWithdrawalTransaction })
 
   // Wait a few extra seconds for processing
   await sleep(1000 * 5);
@@ -123,6 +125,7 @@ const main = async () => {
     functionName: 'finalizeWithdrawal',
   });
   console.log(`Finalize withdrawal transaction sent: ${finalizeWithdrawalTransaction}`);
+  await client.waitForTransactionReceipt({ hash: finalizeWithdrawalTransaction })
 
   // Wait a few extra seconds for processing
   await sleep(1000 * 5);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -116,4 +116,5 @@ export const sendTransactionToTriggerNewBlock = async (
   if (verbose) {
     console.log(`Transaction sent: ${hash}`);
   }
+  await client.waitForTransactionReceipt({ hash: hash })
 };

--- a/src/timeboostHelpers.ts
+++ b/src/timeboostHelpers.ts
@@ -106,6 +106,7 @@ export const checkDepositedFundsInAuctionContract = async ({
       chain: client.chain!,
     });
     console.log(`Approve transaction sent: ${approveHash}`);
+    await client.waitForTransactionReceipt({ hash: approveHash })
 
     // Making the deposit
     const depositHash = await client.writeContract({
@@ -117,6 +118,7 @@ export const checkDepositedFundsInAuctionContract = async ({
       chain: client.chain!,
     });
     console.log(`Deposit transaction sent: ${depositHash}`);
+    await client.waitForTransactionReceipt({ hash: depositHash })
   }
 };
 


### PR DESCRIPTION
In my local environment when running a sequencer in tx fowarder configuration, it is possible when the test is running targeting the forwarder that it gets an old nonce due to delays in state propagation from the active sequencer to the forwarder. This change makes all txs wait for a receipt before proceeding. 